### PR TITLE
Make error handling more consistent

### DIFF
--- a/src/xdr_builtin.c
+++ b/src/xdr_builtin.c
@@ -23,7 +23,7 @@
 #define unlikely(x) __builtin_expect(!!(x), 0)
 #define FORCE_INLINE __attribute__((always_inline)) inline
 
-static FORCE_INLINE int
+static FORCE_INLINE int WARN_UNUSED_RESULT
 xdr_iovec_add_offset(
     xdr_iovec *iov,
     int        offset)
@@ -330,7 +330,7 @@ __marshall_uint32_t(
 
 } /* __marshall_uint32_t */
 
-static FORCE_INLINE int
+static FORCE_INLINE int WARN_UNUSED_RESULT
 __unmarshall_uint32_t_vector(
     uint32_t               *v,
     struct xdr_read_cursor *cursor,
@@ -350,7 +350,7 @@ __unmarshall_uint32_t_vector(
     return 4;
 } /* __unmarshall_uint32_t_vector */
 
-static FORCE_INLINE int
+static FORCE_INLINE int WARN_UNUSED_RESULT
 __unmarshall_uint32_t_contig(
     uint32_t               *v,
     struct xdr_read_cursor *cursor,
@@ -376,7 +376,7 @@ __marshall_int32_t(
     cursor->scratch_used += 4;
 } /* __marshall_int32_t */
 
-static FORCE_INLINE int
+static FORCE_INLINE int WARN_UNUSED_RESULT
 __unmarshall_int32_t_vector(
     int32_t                *v,
     struct xdr_read_cursor *cursor,
@@ -422,7 +422,7 @@ __marshall_uint64_t(
     cursor->scratch_used += 8;
 } /* __marshall_uint64_t */
 
-static FORCE_INLINE int
+static FORCE_INLINE int WARN_UNUSED_RESULT
 __unmarshall_uint64_t_vector(
     uint64_t               *v,
     struct xdr_read_cursor *cursor,
@@ -468,7 +468,7 @@ __marshall_int64_t(
     cursor->scratch_used += 8;
 } /* __marshall_int64_t */
 
-static FORCE_INLINE int
+static FORCE_INLINE int WARN_UNUSED_RESULT
 __unmarshall_int64_t_vector(
     int64_t                *v,
     struct xdr_read_cursor *cursor,
@@ -508,7 +508,7 @@ __marshall_float(
     xdr_write_cursor_append(cursor, v, 4);
 } /* __marshall_float */
 
-static FORCE_INLINE int
+static FORCE_INLINE int WARN_UNUSED_RESULT
 __unmarshall_float_vector(
     float                  *v,
     struct xdr_read_cursor *cursor,
@@ -517,7 +517,7 @@ __unmarshall_float_vector(
     return xdr_read_cursor_vector_extract(cursor, v, 4);
 } /* __unmarshall_float_vector */
 
-static FORCE_INLINE int
+static FORCE_INLINE int WARN_UNUSED_RESULT
 __unmarshall_float_contig(
     float                  *v,
     struct xdr_read_cursor *cursor,
@@ -537,7 +537,7 @@ __marshall_double(
     xdr_write_cursor_append(cursor, v, 8);
 } /* __marshall_double */
 
-static FORCE_INLINE int
+static FORCE_INLINE int WARN_UNUSED_RESULT
 __unmarshall_double_vector(
     double                 *v,
     struct xdr_read_cursor *cursor,
@@ -546,7 +546,7 @@ __unmarshall_double_vector(
     return xdr_read_cursor_vector_extract(cursor, v, 8);
 } /* __unmarshall_double_vector */
 
-static FORCE_INLINE int
+static FORCE_INLINE int WARN_UNUSED_RESULT
 __unmarshall_double_contig(
     double                 *v,
     struct xdr_read_cursor *cursor,
@@ -577,7 +577,7 @@ __marshall_xdr_string(
     }
 } /* __marshall_xdr_string */
 
-static FORCE_INLINE int
+static FORCE_INLINE int WARN_UNUSED_RESULT
 __unmarshall_xdr_string_vector(
     xdr_string             *str,
     struct xdr_read_cursor *cursor,
@@ -630,7 +630,7 @@ __unmarshall_xdr_string_vector(
     return len;
 } /* __unmarshall_xdr_string_vector */
 
-static FORCE_INLINE int
+static FORCE_INLINE int WARN_UNUSED_RESULT
 __unmarshall_xdr_string_contig(
     xdr_string             *str,
     struct xdr_read_cursor *cursor,
@@ -663,7 +663,7 @@ __unmarshall_xdr_string_contig(
 
 
 
-static FORCE_INLINE int
+static FORCE_INLINE int WARN_UNUSED_RESULT
 __unmarshall_opaque_fixed_vector(
     xdr_iovecr             *v,
     uint32_t                size,
@@ -711,7 +711,7 @@ __unmarshall_opaque_fixed_vector(
     return size + pad;
 } /* __unmarshall_opaque_fixed_vector */
 
-static FORCE_INLINE int
+static FORCE_INLINE int WARN_UNUSED_RESULT
 __unmarshall_opaque_fixed_contig(
     xdr_iovecr             *v,
     uint32_t                size,
@@ -815,7 +815,7 @@ __marshall_opaque_zerocopy(
     }
 } /* __marshall_opaque_zerocopy */
 
-static FORCE_INLINE int
+static FORCE_INLINE int WARN_UNUSED_RESULT
 __unmarshall_opaque_vector(
     xdr_opaque             *v,
     uint32_t                bound,
@@ -862,7 +862,7 @@ __unmarshall_opaque_vector(
     return 4 + v->len + pad;
 } /* __unmarshall_opaque_variable_bound_vector */
 
-static FORCE_INLINE int
+static FORCE_INLINE int WARN_UNUSED_RESULT
 __unmarshall_opaque_contig(
     xdr_opaque             *v,
     uint32_t                bound,
@@ -892,7 +892,7 @@ __unmarshall_opaque_contig(
     return len;
 } /* __unmarshall_opaque_contig */
 
-static FORCE_INLINE int
+static FORCE_INLINE int WARN_UNUSED_RESULT
 __unmarshall_opaque_zerocopy_vector(
     xdr_iovecr             *v,
     struct xdr_read_cursor *cursor,
@@ -930,7 +930,7 @@ __unmarshall_opaque_zerocopy_vector(
     return 4 + rc;
 } /* __unmarshall_opaque_variable_vector */
 
-static FORCE_INLINE int
+static FORCE_INLINE int WARN_UNUSED_RESULT
 __unmarshall_opaque_zerocopy_contig(
     xdr_iovecr             *v,
     struct xdr_read_cursor *cursor,

--- a/src/xdr_builtin.c
+++ b/src/xdr_builtin.c
@@ -622,7 +622,10 @@ __unmarshall_xdr_string_vector(
         }
 
     } else {
-        xdr_dbuf_alloc_space(str->str, str->len, dbuf);
+        str->str = xdr_dbuf_alloc_space(str->len, dbuf);
+        if (unlikely(str->str == NULL)) {
+            return -1;
+        }
 
         rc = xdr_read_cursor_vector_extract(cursor, str->str, str->len);
 
@@ -690,7 +693,10 @@ __unmarshall_opaque_fixed_vector(
 {
     int pad, chunk, left = size;
 
-    xdr_dbuf_alloc_space(v->iov, sizeof(*v->iov) * ((cursor->last - cursor->cur) + 1), dbuf);
+    v->iov = xdr_dbuf_alloc_space(sizeof(*v->iov) * ((cursor->last - cursor->cur) + 1), dbuf);
+    if (unlikely(v->iov == NULL)) {
+        return -1;
+    }
 
     v->length = size;
     v->niov   = 0;
@@ -740,7 +746,10 @@ __unmarshall_opaque_fixed_contig(
 
     v->length = size;
     v->niov   = 1;
-    xdr_dbuf_alloc_space(v->iov, sizeof(*v->iov), dbuf);
+    v->iov = xdr_dbuf_alloc_space(sizeof(*v->iov), dbuf);
+    if (unlikely(v->iov == NULL)) {
+        return -1;
+    }
 
     xdr_iovec_set_data(&v->iov[0], (void *) (xdr_iovec_data(cursor->cur) + cursor->iov_offset));
     xdr_iovec_set_len(&v->iov[0], size);
@@ -881,7 +890,10 @@ __unmarshall_opaque_vector(
         }
 
     } else {
-        xdr_dbuf_alloc_space(v->data, v->len, dbuf);
+        v->data = xdr_dbuf_alloc_space(v->len, dbuf);
+        if (unlikely(v->data == NULL)) {
+            return -1;
+        }
 
         rc = xdr_read_cursor_vector_extract(cursor, v->data, v->len);
 

--- a/src/xdr_builtin.h
+++ b/src/xdr_builtin.h
@@ -11,10 +11,14 @@
 #include <stdarg.h>
 #include <stdlib.h>
 
+#ifndef WARN_UNUSED_RESULT
+#define WARN_UNUSED_RESULT __attribute__((warn_unused_result))
+#endif /* ifndef WARN_UNUSED_RESULT */
+
 struct evpl_rpc2_rdma_chunk;
 
 #ifndef XDR_MAX_DBUF
-#define XDR_MAX_DBUF 4096
+#define XDR_MAX_DBUF       4096
 #endif /* ifndef XDR_MAX_DBUF */
 
 typedef struct {

--- a/src/xdr_builtin.h
+++ b/src/xdr_builtin.h
@@ -15,10 +15,18 @@
 #define WARN_UNUSED_RESULT __attribute__((warn_unused_result))
 #endif /* ifndef WARN_UNUSED_RESULT */
 
+#ifndef FORCE_INLINE
+#define FORCE_INLINE       __attribute__((always_inline)) inline
+#endif /* ifndef FORCE_INLINE */
+
+#ifndef unlikely
+#define unlikely(x) __builtin_expect(!!(x), 0)
+#endif /* ifndef unlikely */
+
 struct evpl_rpc2_rdma_chunk;
 
 #ifndef XDR_MAX_DBUF
-#define XDR_MAX_DBUF       4096
+#define XDR_MAX_DBUF 4096
 #endif /* ifndef XDR_MAX_DBUF */
 
 typedef struct {
@@ -42,7 +50,7 @@ xdr_dbuf_alloc(int bytes)
 {
     xdr_dbuf *dbuf;
 
-    dbuf = malloc(sizeof(*dbuf));
+    dbuf = (xdr_dbuf *) malloc(sizeof(*dbuf));
 
     dbuf->buffer = malloc(bytes);
 
@@ -65,51 +73,51 @@ xdr_dbuf_reset(xdr_dbuf *dbuf)
     dbuf->used = 0;
 } /* xdr_dbuf_reset */
 
-#define xdr_dbuf_alloc_space(ptr, isize, dbuf)      \
-        {                                                     \
-            if ((dbuf)->used + (isize) > (dbuf)->size) abort(); \
-            (ptr)         = (dbuf)->buffer + (dbuf)->used;    \
-            (dbuf)->used += (isize); \
-            (dbuf)->used  = ((dbuf)->used + 7) & ~7; \
-        }
+static FORCE_INLINE void * WARN_UNUSED_RESULT
+xdr_dbuf_alloc_space(
+    int       isize,
+    xdr_dbuf *dbuf)
+{
+    void *ptr;
 
-#define xdr_dbuf_alloc_opaque(opaque, ilen, dbuf) \
-        {                                      \
-            (opaque)->len = (ilen);             \
-            xdr_dbuf_alloc_space((opaque)->data, (ilen), (dbuf)); \
-        }
+    if (unlikely(dbuf->used + isize > dbuf->size)) {
+        return NULL;
+    }
+    ptr         = (char *) dbuf->buffer + dbuf->used;
+    dbuf->used += isize;
+    dbuf->used  = (dbuf->used + 7) & ~7;
+    return ptr;
+} // xdr_dbuf_alloc_space
 
-#define xdr_dbuf_opaque_copy(opaque, ptr, ilen, dbuf) \
-        {                                      \
-            (opaque)->len = (ilen);             \
-            xdr_dbuf_alloc_space((opaque)->data, (ilen), (dbuf)); \
-            memcpy((opaque)->data, (ptr), (ilen)); \
-        }
+static FORCE_INLINE int WARN_UNUSED_RESULT
+xdr_dbuf_alloc_opaque(
+    xdr_opaque *opaque,
+    uint32_t    ilen,
+    xdr_dbuf   *dbuf)
+{
+    opaque->len  = ilen;
+    opaque->data = xdr_dbuf_alloc_space(ilen, dbuf);
+    if (unlikely(opaque->data == NULL)) {
+        return -1;
+    }
+    return 0;
+} // xdr_dbuf_alloc_opaque
 
-#define xdr_dbuf_reserve(structp, member, num, dbuf)      \
-        {                                                     \
-            (structp)->num_ ## member = num;                    \
-            xdr_dbuf_alloc_space((structp)->member, num * sizeof(*((structp)->member)), (dbuf)); \
-        }
-
-#define xdr_dbuf_reserve_str(structp, member, ilen, dbuf) \
-        {                                                                  \
-            (structp)->member.len = (ilen);                                \
-            xdr_dbuf_alloc_space((structp)->member.str, (ilen) + 1, (dbuf)); \
-        }
-
-#define xdr_dbuf_strncpy(structp, member, istr, ilen, dbuf)            \
-        {                                                                  \
-            xdr_dbuf_reserve_str(structp, member, ilen, dbuf);              \
-            memcpy((structp)->member.str, (istr), (ilen) + 1);             \
-        }
-
-#define xdr_dbuf_memcpy(object, ibuf, ilen, dbuf)             \
-        {                                                                  \
-            (object)->len = (ilen);                                \
-            xdr_dbuf_alloc_space((object)->data, (ilen), (dbuf));  \
-            memcpy((object)->data, (ibuf), (ilen));                \
-        }
+static FORCE_INLINE int WARN_UNUSED_RESULT
+xdr_dbuf_opaque_copy(
+    xdr_opaque *opaque,
+    const void *ptr,
+    uint32_t    ilen,
+    xdr_dbuf   *dbuf)
+{
+    opaque->len  = ilen;
+    opaque->data = xdr_dbuf_alloc_space(ilen, dbuf);
+    if (unlikely(opaque->data == NULL)) {
+        return -1;
+    }
+    memcpy(opaque->data, ptr, ilen);
+    return 0;
+} // xdr_dbuf_opaque_copy
 
 #define xdr_set_str_static(structp, member, istr, ilen) \
         {                                                   \

--- a/src/xdrzcc.c
+++ b/src/xdrzcc.c
@@ -1116,6 +1116,7 @@ emit_program(
 
         /* Call has an argument */
         if (strcmp(functionp->reply_type->name, "void")) {
+            fprintf(source, "        {\n");
             /* We will unmarshall argument into provided buffer */
             fprintf(source, "        struct %s *%s_arg;\n",
                     functionp->reply_type->name,
@@ -1137,6 +1138,7 @@ emit_program(
             fprintf(source,
                     "        callback_%s(evpl, %s_arg, 0, callback_private_data);\n",
                     functionp->name, functionp->name);
+            fprintf(source, "        }\n");
         } else {
             fprintf(source,
                     " void (*callback_%s)(struct evpl *evpl, int status, void *callback_private_data) = callback_fn;\n",

--- a/src/xdrzcc.c
+++ b/src/xdrzcc.c
@@ -932,13 +932,13 @@ emit_program_header(
 
         if (strcmp(functionp->reply_type->name, "void")) {
             fprintf(header,
-                    "   int (*send_reply_%s)(struct evpl *evpl, struct %s *, void *);\n",
+                    "   int WARN_UNUSED_RESULT (*send_reply_%s)(struct evpl *evpl, struct %s *, void *);\n",
                     functionp->name,
                     functionp->reply_type->name);
 
         } else {
             fprintf(header,
-                    "   int (*send_reply_%s)(struct evpl *evpl, void *);\n",
+                    "   int WARN_UNUSED_RESULT (*send_reply_%s)(struct evpl *evpl, void *);\n",
                     functionp->name);
         }
 
@@ -1137,8 +1137,8 @@ emit_program(
             fprintf(source, "{\n");
             fprintf(source, "    struct evpl_rpc2_msg *msg = private_data;\n");
             fprintf(source, "    struct evpl_iovec iov, *msg_iov;\n");
-            fprintf(source, "    int niov, msg_niov = 256,len;\n");
-            fprintf(source, "    xdr_dbuf_alloc_space(msg_iov, sizeof(*msg_iov) * 256, msg->dbuf);\n");
+            fprintf(source, "    int niov, msg_niov = 260,len;\n");
+            fprintf(source, "    xdr_dbuf_alloc_space(msg_iov, sizeof(*msg_iov) * 260, msg->dbuf);\n");
             fprintf(source,
                     "    niov = evpl_iovec_reserve(evpl, 128*1024, 8, 1, &iov);\n");
             fprintf(source, "    if (unlikely(niov != 1)) return 1;\n");
@@ -1198,7 +1198,7 @@ emit_program(
         fprintf(source, "    void *callback_private_data)\n");
         fprintf(source, "{\n");
         fprintf(source, "    struct evpl_iovec iov, *msg_iov;\n");
-        fprintf(source, "    int msg_niov = 256, len;\n");
+        fprintf(source, "    int msg_niov = 260, len;\n");
         fprintf(source, "    xdr_dbuf *dbuf = (xdr_dbuf *) conn->thread_dbuf;\n");
 
         if (has_args) {
@@ -1207,7 +1207,7 @@ emit_program(
             fprintf(source, "    rdma_chunk.max_length = conn->rdma && ddp ? UINT32_MAX : 0;\n");
             fprintf(source, "    rdma_chunk.niov = 0;\n");
             fprintf(source, "    xdr_dbuf_reset(dbuf);\n");
-            fprintf(source, "    xdr_dbuf_alloc_space(msg_iov, sizeof(*msg_iov) * 256, dbuf);\n");
+            fprintf(source, "    xdr_dbuf_alloc_space(msg_iov, sizeof(*msg_iov) * 260, dbuf);\n");
             fprintf(source, "    evpl_iovec_reserve(evpl, 128*1024, 8, 1, &iov);\n\n");
 
             fprintf(source, "    len = marshall_%s(args, &iov, msg_iov, &msg_niov, "
@@ -1346,7 +1346,7 @@ emit_wrappers(
     FILE       *source,
     const char *name)
 {
-    fprintf(source, "int\n");
+    fprintf(source, "int WARN_UNUSED_RESULT\n");
     fprintf(source, "marshall_%s(\n", name);
     fprintf(source, "    const struct %s *out,\n", name);
     fprintf(source, "    xdr_iovec *iov_in,\n");
@@ -1363,7 +1363,7 @@ emit_wrappers(
     fprintf(source, "    return cursor.total;\n");
     fprintf(source, "}\n\n");
 
-    fprintf(source, "int\n");
+    fprintf(source, "int WARN_UNUSED_RESULT\n");
     fprintf(source, "unmarshall_%s(\n", name);
     fprintf(source, "    struct %s *out,\n", name);
     fprintf(source, "    const xdr_iovec *iov,\n");
@@ -1818,9 +1818,9 @@ main(
         fprintf(source, "}\n\n");
 
         if (is_recursive) {
-            fprintf(source, "static int\n");
+            fprintf(source, "static int WARN_UNUSED_RESULT\n");
         } else {
-            fprintf(source, "static FORCE_INLINE int\n");
+            fprintf(source, "static FORCE_INLINE int WARN_UNUSED_RESULT\n");
         }
         fprintf(source, "__unmarshall_%s_vector(\n", xdr_structp->name);
         fprintf(source, "    struct %s *out,\n", xdr_structp->name);
@@ -1843,9 +1843,9 @@ main(
         fprintf(source, "}\n\n");
 
         if (is_recursive) {
-            fprintf(source, "static int\n");
+            fprintf(source, "static int WARN_UNUSED_RESULT\n");
         } else {
-            fprintf(source, "static FORCE_INLINE int\n");
+            fprintf(source, "static FORCE_INLINE int WARN_UNUSED_RESULT\n");
         }
         fprintf(source, "__unmarshall_%s_contig(\n", xdr_structp->name);
         fprintf(source, "    struct %s *out,\n", xdr_structp->name);
@@ -1923,9 +1923,9 @@ main(
         fprintf(source, "}\n\n");
 
         if (is_recursive) {
-            fprintf(source, "static int\n");
+            fprintf(source, "static int WARN_UNUSED_RESULT\n");
         } else {
-            fprintf(source, "static FORCE_INLINE int\n");
+            fprintf(source, "static FORCE_INLINE int WARN_UNUSED_RESULT\n");
         }
         fprintf(source, "__unmarshall_%s_vector(\n", xdr_unionp->name);
         fprintf(source, "    struct %s *out,\n", xdr_unionp->name);
@@ -1970,9 +1970,9 @@ main(
         fprintf(source, "}\n\n");
 
         if (is_recursive) {
-            fprintf(source, "static int\n");
+            fprintf(source, "static int WARN_UNUSED_RESULT\n");
         } else {
-            fprintf(source, "static FORCE_INLINE int\n");
+            fprintf(source, "static FORCE_INLINE int WARN_UNUSED_RESULT\n");
         }
         fprintf(source, "__unmarshall_%s_contig(\n", xdr_unionp->name);
         fprintf(source, "    struct %s *out,\n", xdr_unionp->name);

--- a/src/xdrzcc.c
+++ b/src/xdrzcc.c
@@ -777,10 +777,17 @@ emit_length_struct(
     struct xdr_struct *xdr_structp)
 {
     struct xdr_struct_member *member;
+    int                       is_recursive = is_type_recursive(name);
 
-    fprintf(source,
-            "static int __marshall_length_%s(const struct %s *in)\n",
-            name, name);
+    if (is_recursive) {
+        fprintf(source,
+                "static int __marshall_length_%s(const struct %s *in)\n",
+                name, name);
+    } else {
+        fprintf(source,
+                "static FORCE_INLINE int __marshall_length_%s(const struct %s *in)\n",
+                name, name);
+    }
 
     fprintf(source, "{\n");
     fprintf(source, "    uint32_t length = 0;\n");
@@ -854,10 +861,17 @@ emit_length_union(
     struct xdr_union *xdr_unionp)
 {
     struct xdr_union_case *casep;
+    int                    is_recursive = is_type_recursive(name);
 
-    fprintf(source,
-            "static int __marshall_length_%s(const struct %s *in)\n",
-            name, name);
+    if (is_recursive) {
+        fprintf(source,
+                "static int __marshall_length_%s(const struct %s *in)\n",
+                name, name);
+    } else {
+        fprintf(source,
+                "static FORCE_INLINE int __marshall_length_%s(const struct %s *in)\n",
+                name, name);
+    }
     fprintf(source, "{\n");
     fprintf(source, "    uint32_t length = 0;\n");
     emit_length_member(source, xdr_unionp->pivot_name, xdr_unionp->pivot_type);

--- a/tests/string.c
+++ b/tests/string.c
@@ -22,9 +22,26 @@ main(
 
     dbuf = xdr_dbuf_alloc(16 * 1024);
 
-    xdr_dbuf_strncpy(&msg1, string1, "1234567", 7, dbuf);
-    xdr_dbuf_strncpy(&msg1, string2, "1234", 4, dbuf);
-    xdr_dbuf_strncpy(&msg1, string3, "123456789", 9, dbuf);
+    msg1.string1.len = 7;
+    msg1.string1.str = (char *)xdr_dbuf_alloc_space(7 + 1, dbuf);
+    if (msg1.string1.str == NULL) {
+        return 1;
+    }
+    memcpy(msg1.string1.str, "1234567", 7 + 1);
+
+    msg1.string2.len = 4;
+    msg1.string2.str = (char *)xdr_dbuf_alloc_space(4 + 1, dbuf);
+    if (msg1.string2.str == NULL) {
+        return 1;
+    }
+    memcpy(msg1.string2.str, "1234", 4 + 1);
+
+    msg1.string3.len = 9;
+    msg1.string3.str = (char *)xdr_dbuf_alloc_space(9 + 1, dbuf);
+    if (msg1.string3.str == NULL) {
+        return 1;
+    }
+    memcpy(msg1.string3.str, "123456789", 9 + 1);
 
     rc = marshall_MyMsg(&msg1, &iov_in, &iov_out, &one, NULL, 0);
 

--- a/tests/uint32_vector.c
+++ b/tests/uint32_vector.c
@@ -22,7 +22,11 @@ main(
 
     dbuf = xdr_dbuf_alloc(16 * 1024);
 
-    xdr_dbuf_reserve(&msg1, value, 16, dbuf);
+    msg1.num_value = 16;
+    msg1.value = xdr_dbuf_alloc_space(16 * sizeof(*msg1.value), dbuf);
+    if (msg1.value == NULL) {
+        return 1;
+    }
 
     for (i = 0; i < 16; ++i) {
         msg1.value[i] = i;

--- a/tests/uint32_vector_one.c
+++ b/tests/uint32_vector_one.c
@@ -22,7 +22,11 @@ main(
 
     dbuf = xdr_dbuf_alloc(16 * 1024);
 
-    xdr_dbuf_reserve(&msg1, value, 1, dbuf);
+    msg1.num_value = 1;
+    msg1.value = xdr_dbuf_alloc_space(1 * sizeof(*msg1.value), dbuf);
+    if (msg1.value == NULL) {
+        return 1;
+    }
     msg1.value[0] = 42;
 
     rc = marshall_MyMsg(&msg1, &iov_in, &iov_out, &one, NULL, 0);


### PR DESCRIPTION
There were places in the generated xdr marshaling code where it would just call abort() if insufficient space was provided or if the input could not be deserialized.    Convert all of this error handling into return codes that export up to the application above to deal with, and set warn unused result attribute on all the relevant functions to make sure application layer handles the errors.

Also force inline the marshall_length helper routines as we were already the marshall/unmarshall functions.