### PR TITLE
Refactor of RPC2 generated code in service of handling RPC2 authentication properly in NFS

### DIFF
--- a/src/xdr.h
+++ b/src/xdr.h
@@ -86,6 +86,7 @@ struct xdr_union {
     char                  *pivot_name;
     struct xdr_union_case *cases;
     struct xdr_union_case *default_case;
+    int                    opaque;  /* opaque_union: length prefix for wire compatibility */
     struct xdr_union      *prev;
     struct xdr_union      *next;
 

--- a/src/xdr.l
+++ b/src/xdr.l
@@ -46,6 +46,7 @@ char * xdr_strdup(const char *str);
 "opaque"        { column_num += yyleng; return OPAQUE; }
 "zcopaque"      { column_num += yyleng; return ZCOPAQUE; }
 "union"         { column_num += yyleng; return UNION; }
+"opaque_union"  { column_num += yyleng; return OPAQUE_UNION; }
 "switch"        { column_num += yyleng; return SWITCH; }
 "case"          { column_num += yyleng; return CASE; }
 "default"       { column_num += yyleng; return DEFAULT; }

--- a/src/xdr.y
+++ b/src/xdr.y
@@ -56,7 +56,7 @@ void yyerror(const char *s) {
 %token <str> IDENTIFIER NUMBER
 %token UINT32 INT32 UINT64 INT64
 %token INT LONG UNSIGNED FLOAT DOUBLE BOOL ENUM STRUCT TYPEDEF
-%token VOID STRING OPAQUE ZCOPAQUE UNION SWITCH CASE DEFAULT CONST
+%token VOID STRING OPAQUE ZCOPAQUE UNION OPAQUE_UNION SWITCH CASE DEFAULT CONST
 %token LBRACE RBRACE LPAREN RPAREN SEMICOLON COLON EQUALS
 %token LBRACKET RBRACKET STAR LANGLE RANGLE COMMA PROGRAM VERSION
 
@@ -342,6 +342,16 @@ union_def:
         $$->pivot_name = $6;
         $$->pivot_type = $5;
         $$->cases = $9;
+        $$->opaque = 0;
+    }
+    | OPAQUE_UNION IDENTIFIER SWITCH LPAREN type IDENTIFIER RPAREN LBRACE union_body RBRACE
+    {
+        $$ = xdr_alloc(sizeof(*$$));
+        $$->name = $2;
+        $$->pivot_name = $6;
+        $$->pivot_type = $5;
+        $$->cases = $9;
+        $$->opaque = 1;
     }
     ;
 
@@ -376,7 +386,34 @@ case_clause:
         $$->type = $2;
         $$->name = $3;
     }
-    | case_label 
+    | case_label type IDENTIFIER LANGLE NUMBER RANGLE SEMICOLON
+    {
+        $$ = xdr_alloc(sizeof(*$$));
+        $$->label = $1;
+        $$->type = $2;
+        $$->name = $3;
+        $$->type->vector = 1;
+        $$->type->vector_bound = $5;
+    }
+    | case_label type IDENTIFIER LANGLE IDENTIFIER RANGLE SEMICOLON
+    {
+        $$ = xdr_alloc(sizeof(*$$));
+        $$->label = $1;
+        $$->type = $2;
+        $$->name = $3;
+        $$->type->vector = 1;
+        $$->type->vector_bound = $5;
+    }
+    | case_label type IDENTIFIER LANGLE RANGLE SEMICOLON
+    {
+        $$ = xdr_alloc(sizeof(*$$));
+        $$->label = $1;
+        $$->type = $2;
+        $$->name = $3;
+        $$->type->vector = 1;
+        $$->type->vector_bound = NULL;
+    }
+    | case_label
     {
         $$ = xdr_alloc(sizeof(*$$));
         $$->label = $1;

--- a/src/xdr_builtin.h
+++ b/src/xdr_builtin.h
@@ -49,10 +49,12 @@ struct xdr_dbuf {
     int   used;
 };
 typedef struct xdr_dbuf xdr_dbuf;
-#endif
+#endif // ifndef XDR_DBUF_DEFINED
 
 static inline void
-xdr_dbuf_init(xdr_dbuf *dbuf, int bytes)
+xdr_dbuf_init(
+    xdr_dbuf *dbuf,
+    int       bytes)
 {
     dbuf->buffer = malloc(bytes);
     dbuf->used   = 0;

--- a/src/xdr_builtin.h
+++ b/src/xdr_builtin.h
@@ -41,11 +41,32 @@ typedef struct {
     void    *data;
 } xdr_opaque;
 
-typedef struct {
+#ifndef XDR_DBUF_DEFINED
+#define XDR_DBUF_DEFINED
+struct xdr_dbuf {
     void *buffer;
     int   size;
     int   used;
-} xdr_dbuf;
+};
+typedef struct xdr_dbuf xdr_dbuf;
+#endif
+
+static inline void
+xdr_dbuf_init(xdr_dbuf *dbuf, int bytes)
+{
+    dbuf->buffer = malloc(bytes);
+    dbuf->used   = 0;
+    dbuf->size   = bytes;
+} /* xdr_dbuf_init */
+
+static inline void
+xdr_dbuf_destroy(xdr_dbuf *dbuf)
+{
+    free(dbuf->buffer);
+    dbuf->buffer = NULL;
+    dbuf->size   = 0;
+    dbuf->used   = 0;
+} /* xdr_dbuf_destroy */
 
 static inline xdr_dbuf *
 xdr_dbuf_alloc(int bytes)
@@ -53,11 +74,7 @@ xdr_dbuf_alloc(int bytes)
     xdr_dbuf *dbuf;
 
     dbuf = (xdr_dbuf *) malloc(sizeof(*dbuf));
-
-    dbuf->buffer = malloc(bytes);
-
-    dbuf->used = 0;
-    dbuf->size = bytes;
+    xdr_dbuf_init(dbuf, bytes);
 
     return dbuf;
 } /* xdr_dbuf_alloc */
@@ -65,7 +82,7 @@ xdr_dbuf_alloc(int bytes)
 static inline void
 xdr_dbuf_free(xdr_dbuf *dbuf)
 {
-    free(dbuf->buffer);
+    xdr_dbuf_destroy(dbuf);
     free(dbuf);
 } /* xdr_dbuf_free */
 

--- a/src/xdrzcc.c
+++ b/src/xdrzcc.c
@@ -1489,7 +1489,8 @@ emit_program(
                         reply_type_buf);
             }
         } else {
-            fprintf(source, "    void (*callback)(struct evpl *evpl, const struct evpl_rpc2_verf *verf, int status, void *callback_private_data),\n");
+            fprintf(source,
+                    "    void (*callback)(struct evpl *evpl, const struct evpl_rpc2_verf *verf, int status, void *callback_private_data),\n");
         }
 
 
@@ -2409,7 +2410,8 @@ main(
 
         if (xdr_unionp->opaque) {
             /* Verify consumed bytes match expected length (unless skipped) */
-            fprintf(source, "    if (!skip_body_len_check && unlikely((uint32_t)(len - body_start_len) != expected_body_len)) return -1;\n");
+            fprintf(source,
+                    "    if (!skip_body_len_check && unlikely((uint32_t)(len - body_start_len) != expected_body_len)) return -1;\n");
         }
 
         fprintf(source, "    return len;\n");
@@ -2508,7 +2510,8 @@ main(
 
         if (xdr_unionp->opaque) {
             /* Verify consumed bytes match expected length (unless skipped) */
-            fprintf(source, "    if (!skip_body_len_check && unlikely((uint32_t)(len - body_start_len) != expected_body_len)) return -1;\n");
+            fprintf(source,
+                    "    if (!skip_body_len_check && unlikely((uint32_t)(len - body_start_len) != expected_body_len)) return -1;\n");
         }
 
         fprintf(source, "    return len;\n");


### PR DESCRIPTION
Add an "extension" to the XDR language called an "opaque_union".  An opaque_union is just like a regular union, except when marshaled it is marshaled as though we marshaled as though we took a separate XDR object, marshaled it, and then encoded it into another XDR object as an opaque blob.   If a union member is itself opaque, then it is encoded directly to avoid double length headers.

This is done to more efficiently and simply support RPC2 authentication blobs.  They are normally encoded as an opaque blob in RPC2 even though often they are themselves XDR types.  The opaque_union lets us encode and decode these properly without any extra steps or memory copies.

Update generated RPC2 code to pass credentials and verifiers through to/from application.