### PR TITLE
codegen: deliver malformed-reply errors to the callback instead of aborting

### DIFF
--- a/src/xdrzcc.c
+++ b/src/xdrzcc.c
@@ -1298,11 +1298,31 @@ emit_program(
 
         /* Call has an argument */
         if (strcmp(functionp->reply_type->name, "void")) {
+            /* A reply that fails to decode (truncated / malformed / wrong
+             * length) is a peer fault, not a server bug: deliver it to the
+             * callback as EVPL_RPC2_REPLY_DECODE_ERROR (reply NULL, or a zero
+             * value for a by-value reply) and return success, so the caller's
+             * completion runs and cleans up rather than rpc2.c aborting the
+             * whole process.  The callback is declared up front so the error
+             * paths can reach it.  `err_reply` is the reply argument passed on
+             * the error path. */
+            int         byvalue   = is_byvalue_builtin(functionp->reply_type);
+            const char *err_reply = byvalue ? "0" : "NULL";
+
             fprintf(source, "        {\n");
             /* We will unmarshall argument into provided buffer */
             fprintf(source, "        %s *%s_arg;\n",
                     reply_type_buf,
                     functionp->name);
+            if (byvalue) {
+                fprintf(source,
+                        "        void (*callback_%s)(struct evpl *evpl, const struct evpl_rpc2_verf *verf, %s reply, int status, void *callback_private_data) = callback_fn;\n",
+                        functionp->name, reply_type_buf);
+            } else {
+                fprintf(source,
+                        "        void (*callback_%s)(struct evpl *evpl, const struct evpl_rpc2_verf *verf, %s *reply, int status, void *callback_private_data) = callback_fn;\n",
+                        functionp->name, reply_type_buf);
+            }
             if (functionp->reply_type->array) {
                 fprintf(source, "        %s_arg = xdr_dbuf_alloc_space(sizeof(*%s_arg) * %s, dbuf);\n",
                         functionp->name, functionp->name, functionp->reply_type->array_size);
@@ -1323,7 +1343,9 @@ emit_program(
                 fprintf(source,
                         "                    int _rc = __unmarshall_%s_contig(&%s_arg[_i], &cursor, dbuf);\n",
                         functionp->reply_type->name, functionp->name);
-                fprintf(source, "                    if (unlikely(_rc < 0)) return 2;\n");
+                fprintf(source,
+                        "                    if (unlikely(_rc < 0)) { callback_%s(evpl, verf, %s, EVPL_RPC2_REPLY_DECODE_ERROR, callback_private_data); return 0; }\n",
+                        functionp->name, err_reply);
                 fprintf(source, "                    len += _rc;\n");
                 fprintf(source, "                }\n");
                 fprintf(source, "            } else {\n");
@@ -1333,7 +1355,9 @@ emit_program(
                 fprintf(source,
                         "                    int _rc = __unmarshall_%s_vector(&%s_arg[_i], &cursor, dbuf);\n",
                         functionp->reply_type->name, functionp->name);
-                fprintf(source, "                    if (unlikely(_rc < 0)) return 2;\n");
+                fprintf(source,
+                        "                    if (unlikely(_rc < 0)) { callback_%s(evpl, verf, %s, EVPL_RPC2_REPLY_DECODE_ERROR, callback_private_data); return 0; }\n",
+                        functionp->name, err_reply);
                 fprintf(source, "                    len += _rc;\n");
                 fprintf(source, "                }\n");
                 fprintf(source, "            }\n");
@@ -1343,21 +1367,16 @@ emit_program(
                         "        len = unmarshall_%s(%s_arg, iov, niov, read_chunk, dbuf);\n",
                         functionp->reply_type->name, functionp->name);
             }
-            fprintf(source, "        if (unlikely(len != length)) return 2;\n");
-            fprintf(source, "        if (len < 0) return 2;\n");
+            fprintf(source,
+                    "        if (unlikely(len != length || len < 0)) { callback_%s(evpl, verf, %s, EVPL_RPC2_REPLY_DECODE_ERROR, callback_private_data); return 0; }\n",
+                    functionp->name, err_reply);
 
             /* Then make the call - builtin scalars are passed by value */
-            if (is_byvalue_builtin(functionp->reply_type)) {
-                fprintf(source,
-                        " void (*callback_%s)(struct evpl *evpl, const struct evpl_rpc2_verf *verf, %s reply, int status, void *callback_private_data) = callback_fn;\n",
-                        functionp->name, reply_type_buf);
+            if (byvalue) {
                 fprintf(source,
                         "        callback_%s(evpl, verf, *%s_arg, 0, callback_private_data);\n",
                         functionp->name, functionp->name);
             } else {
-                fprintf(source,
-                        " void (*callback_%s)(struct evpl *evpl, const struct evpl_rpc2_verf *verf, %s *reply, int status, void *callback_private_data) = callback_fn;\n",
-                        functionp->name, reply_type_buf);
                 fprintf(source,
                         "        callback_%s(evpl, verf, %s_arg, 0, callback_private_data);\n",
                         functionp->name, functionp->name);


### PR DESCRIPTION
## Summary

The generated client reply dispatcher (`reply_dispatch_<program>`) returns an error code to the rpc2 layer when a peer's reply fails to decode — truncated, malformed, or `len != length`. `rpc2.c` turns any nonzero return from `recv_reply_dispatch` into `evpl_rpc2_abort()`, so **a peer sending a bad reply crashes the whole process**. And because the dispatcher returned before invoking the per-request completion callback, even without the abort the caller would hang and leak its request.

This was hit in practice by a chimera NFSv4.1 delegation-recall test: the peer's callback server died mid-reply and sent a truncated `CB_COMPOUND` reply, which aborted the chimera server.

## Change

In the generated reply dispatcher, declare the typed reply callback up front and, on any decode error, invoke it with `EVPL_RPC2_REPLY_DECODE_ERROR` (reply `NULL`, or a zero value for a by-value reply) and `return 0`. The caller's completion then runs and treats it as a failed call — existing callbacks already check `status` before touching the reply. Out-of-memory (allocation failure) and an impossible reply proc remain hard errors.

`EVPL_RPC2_REPLY_DECODE_ERROR` is defined in libevpl's `evpl/evpl_rpc2_program.h` (a companion libevpl change bumps this submodule and adds the constant).

## Testing

- `xdrzcc` builds and its full test suite passes (its test `.x` files define no rpc programs, so the dispatcher codegen is exercised downstream).
- Validated end-to-end in chimera: a peer returning a malformed `CB_COMPOUND` reply previously aborted the server (`evpl_rpc2_abort("Failed to dispatch rpc2 reply: 2")`); with this change the server delivers the error to the recall completion and stays up.