### PR TITLE
codegen: avoid dead store in the optional-pointer contig length fix

### DIFF
--- a/src/xdrzcc.c
+++ b/src/xdrzcc.c
@@ -404,11 +404,9 @@ emit_unmarshall_contig(
                 "        rc = __unmarshall_%s_contig(out->%s, cursor, dbuf);\n",
                 type->name, name);
         fprintf(output, "        if (unlikely(rc < 0)) return rc;\n");
-        fprintf(output, "        len += rc;\n");
         fprintf(output, "        } else {\n");
         fprintf(output, "            out->%s = NULL;\n", name);
         fprintf(output, "        };\n");
-        fprintf(output, "        rc = 0;\n");
         fprintf(output, "    }\n");
     } else if (type->vector) {
         fprintf(output,


### PR DESCRIPTION
Follow-up to #10.

#10 corrected the contig optional-pointer **double-count** by adding a trailing `rc = 0;`. That fixes the length, but it makes the `rc = 0;` already emitted *before* the `if (more)` a dead store on the else path — it's now overwritten before the trailing `len += rc;` reads it. clang's analyzer flags it (`deadcode.DeadStores`, "Value stored to 'rc' is never read") in **every** generated optional-pointer block — `rpcrdma1_xdr.c`, `nfs_mount_xdr.c`, `portmap_xdr.c` — which fails the static-analysis CI on downstream consumers.

### Fix

Drop the inner `len += rc;` instead of adding a second `rc = 0;`, so the optional contig block matches the **vector** emitter:
- the common trailing `len += rc;` already counts the pointed-to object once,
- the `rc = 0;` before the `if` covers the absent case (and is read by the trailing add on that path, so it's not dead).

Same correct consumed length, no dead store.

### Verification

- Regenerated `rpcrdma1`: EXCHANGE_ID (reply chunk present) still parses at offset 48, NULL at 28.
- `clang --analyze -analyzer-checker=deadcode.DeadStores` on the regenerated parser: clean (was 3 warnings).
- Full suite 19/19, including the `tests/optional` round-trip guard from #10.