### PR TITLE
xdr_builtin: take alloc size as size_t to stop count-driven heap overflow

### DIFF
--- a/src/xdr_builtin.h
+++ b/src/xdr_builtin.h
@@ -96,16 +96,21 @@ xdr_dbuf_reset(xdr_dbuf *dbuf)
 
 static FORCE_INLINE void * WARN_UNUSED_RESULT
 xdr_dbuf_alloc_space(
-    int       isize,
+    size_t    isize,
     xdr_dbuf *dbuf)
 {
     void *ptr;
 
-    if (unlikely(dbuf->used + isize > dbuf->size)) {
+    /* isize is size_t so a caller's 64-bit size product (e.g. a wire-supplied
+     * array count times the element size) is compared at full width.  Taking it
+     * as int truncated the product, letting an attacker-controlled count defeat
+     * this bounds check and drive a heap overflow.  Compare in size_t and reject
+     * anything that does not fit the remaining buffer. */
+    if (unlikely((size_t) dbuf->used + isize > (size_t) dbuf->size)) {
         return NULL;
     }
     ptr         = (char *) dbuf->buffer + dbuf->used;
-    dbuf->used += isize;
+    dbuf->used += (int) isize;
     dbuf->used  = (dbuf->used + 7) & ~7;
     return ptr;
 } // xdr_dbuf_alloc_space


### PR DESCRIPTION
`xdr_dbuf_alloc_space` took its allocation size as `int`. Generated array unmarshallers call it with a 64-bit product of a wire-supplied element count and the element size — e.g. the ONC-RPC `authsys_parms` `gids<16>` field decodes as `num_gids * sizeof(uint32_t)`. A large attacker-controlled count makes that product exceed `INT_MAX`; passing it through the `int` parameter truncated it (or made it negative), so the `used + isize > size` bounds check passed for an allocation far larger than the buffer. The generated decoder then wrote `count` elements past the under-sized allocation — a pre-auth heap buffer overflow reachable on every ONC-RPC transport that uses this runtime (NFS/MOUNT/NLM/NSM/portmap via libevpl rpc2).

Fix: take `isize` as `size_t` and do the bounds comparison in `size_t`, so the full-width product is checked. An oversized request now returns `NULL`, and the generated array decoder's existing `if (... == NULL) return -1;` fails the decode cleanly instead of overflowing.

This is the root-cause fix for chimera-nas/chimera#1043. It needs to propagate via a libevpl xdrzcc-submodule bump and then a chimera libevpl-submodule bump. Verified it compiles cleanly across all of chimera's generated XDR unmarshallers (full chimera release rebuild).